### PR TITLE
NO-ISSUE: SPM plugin support in tests

### DIFF
--- a/.github/workflows/run_xcode_tests.yml
+++ b/.github/workflows/run_xcode_tests.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Compile and Test
         timeout-minutes: 90
         run: |
+            touch .ci_tag
             xcodebuild clean test \
+            -skipPackagePluginValidation \
             -workspace ${{ inputs.workspace_name }} \
             -scheme ${{ inputs.scheme_name }} \
             -destination "${destination}" \
@@ -73,6 +75,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             ONLY_ACTIVE_ARCH=NO
+            rm .ci_tag
         env:
            destination: ${{ matrix.destination }}
       - if: ${{ inputs.is_collect_issues }}

--- a/.github/workflows/run_xcode_tests.yml
+++ b/.github/workflows/run_xcode_tests.yml
@@ -60,10 +60,11 @@ jobs:
         run: |
           make install-xcodegen
           make generate-xcodeproj
+      - name: Create ci tag
+        run: touch .ci_tag
       - name: Compile and Test
         timeout-minutes: 90
         run: |
-            touch .ci_tag
             xcodebuild clean test \
             -skipPackagePluginValidation \
             -workspace ${{ inputs.workspace_name }} \
@@ -75,9 +76,10 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             ONLY_ACTIVE_ARCH=NO
-            rm .ci_tag
         env:
            destination: ${{ matrix.destination }}
+      - name: Remove ci tag
+        run: rm .ci_tag
       - if: ${{ inputs.is_collect_issues }}
         continue-on-error: true
         name: Collect issues


### PR DESCRIPTION
Добавил создание метки, что запускаемся на CI (нужно, что плагин линтера не запускался на CI для таргетов проекта)
Добавил пропуск валидации SPM плагина