### PR TITLE
(NO-ISSUE) Удаление отдельной джобы для отмены предыдущих запусков

### DIFF
--- a/.github/workflows/check_android_pr_with_detekt.yml
+++ b/.github/workflows/check_android_pr_with_detekt.yml
@@ -16,20 +16,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cancel_previous_runs:
-    name: 'Cancel Previous Runs'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ secrets.github_access_token }}
-
   check_pr:
-    needs: cancel_previous_runs
-    name: 'Check pull request'
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        runs-on: ubuntu-latest
+        steps:
+          - uses: styfle/cancel-workflow-action@0.11.0
+            with:
+              all_but_latest: true
+              access_token: ${{ secrets.github_access_token }}
+
       - name: Checkout repo
         uses: actions/checkout@v3.1.0
 
@@ -38,7 +35,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-          cache: 'gradle'
 
       - name: Run detekt
         if: success() || failure()

--- a/.github/workflows/check_pull_request.yml
+++ b/.github/workflows/check_pull_request.yml
@@ -11,27 +11,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cancel_previous_runs:
-    name: 'Cancel Previous Runs'
+  check_pr:
     runs-on: ubuntu-latest
+    if: github.event_name  == 'pull_request'
     steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           all_but_latest: true
           access_token: ${{ secrets.github_access_token }}
 
-  check_pr:
-    needs: cancel_previous_runs
-    name: 'Check pull request'
-    runs-on: ubuntu-latest
-    if: github.event_name  == 'pull_request'
-    steps:
       - name: Checkout repo
         uses: actions/checkout@v3.1.0
+
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
+
       - name: Install ruby dependencies
         run: |
           if test -f "Gemfile"; then
@@ -39,6 +36,7 @@ jobs:
             bundle config set --local path 'vendor/bundle'
             bundle install
           fi
+
       - uses: MeilCli/danger-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/run_android_ui_tests.yml
+++ b/.github/workflows/run_android_ui_tests.yml
@@ -28,18 +28,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cancel_previous_runs:
-    name: 'Cancel Previous Runs'
+  run_ui_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           all_but_latest: true
           access_token: ${{ secrets.github_access_token }}
-  run_ui_tests:
-    name: UI tests
-    runs-on: ubuntu-latest
-    steps:
+
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Setup Java 11
@@ -47,6 +44,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
+
       - name: Assemble
         uses: gradle/gradle-build-action@v2
         with:
@@ -55,18 +53,22 @@ jobs:
         env:
           MAVEN_READONLY_TOKEN: ${{ secrets.maven_readonly_token }}
           GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: ${{ inputs.is_gradle_cache_debug_enabled }}
+
       - name: Upload sample debug APK
         uses: actions/upload-artifact@v3
         with:
           name: sample_app-debug
           path: sample_app/build/outputs/apk/debug/sample_app-debug.apk
+
       - name: Upload androidTest APK
         uses: actions/upload-artifact@v3
         with:
           name: sample_app-debug-androidTest
           path: sample_app/build/outputs/apk/androidTest/debug/sample_app-debug-androidTest.apk
+
       - name: Download artifacts
         uses: actions/download-artifact@v3
+
       - name: Run instrumented tests
         uses: Flank/flank@v23.04.0
         with:

--- a/.github/workflows/run_android_unit_tests.yml
+++ b/.github/workflows/run_android_unit_tests.yml
@@ -21,25 +21,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cancel_previous_runs:
-    name: 'Cancel Previous Runs'
+  run_unit_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           all_but_latest: true
           access_token: ${{ secrets.github_access_token }}
-  run_unit_tests:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
+
       - name: Checkout
         uses: actions/checkout@v3.1.0
+
       - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
+
       - name: Run unit tests
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Теперь отмена предыдущих запусков будет происходить внутри основной джобы.
Это делается для того, чтобы убрать шум в списке прогонов на ПРах
<img width="833" alt="Снимок экрана 2023-08-23 в 17 25 16" src="https://github.com/tutu-ru-mobile/github-workflows/assets/10930232/03a63de1-df44-43f3-afab-ebf08a118073">

На примере выдачи проверил
<img width="504" alt="Снимок экрана 2023-08-23 в 17 29 21" src="https://github.com/tutu-ru-mobile/github-workflows/assets/10930232/7007763b-03cb-4085-9693-c78a8d92da24">
