### PR TITLE
NO-ISSUE: handle error linter

### DIFF
--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -47,9 +47,6 @@ jobs:
       run: ./download_project_utils.sh
     - name: Run SwiftLint
       run: |
-        #!/bin/bash
-        set -o pipefail
-        
         SWIFTLINT_DIR="vendor/etc/bin/swiftlint"
 
         url=https://api.github.com/repos/$GITHUB_REPOSITORY/compare/$GITHUB_BASE_REF...$GITHUB_HEAD_REF
@@ -101,7 +98,7 @@ jobs:
                 config_args+="--reporter emoji "
                 config_args+="--config $temp_config "
                 echo "Run with args $config_args"
-                lint_result=$($SWIFTLINT_DIR/swiftlint $config_args $filtered)
+                lint_result=$($SWIFTLINT_DIR/swiftlint $config_args $filtered || true)
                 if [[ -n "$lint_result" ]]; then
                   linter_errors+="$lint_result\n"
                 fi

--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -47,6 +47,9 @@ jobs:
       run: ./download_project_utils.sh
     - name: Run SwiftLint
       run: |
+        #!/bin/bash
+        set -o pipefail
+        
         SWIFTLINT_DIR="vendor/etc/bin/swiftlint"
 
         url=https://api.github.com/repos/$GITHUB_REPOSITORY/compare/$GITHUB_BASE_REF...$GITHUB_HEAD_REF


### PR DESCRIPTION
Заглушил обработку ошибки от линтера. В скрипте реализован свой подход к обработке ошибок линтера и нам не надо, чтобы скрипт завершался раньше времени (когда линтер возвращает не нулевой статус).

Было:
![image](https://github.com/tutu-ru-mobile/github-workflows/assets/13437044/264ec0c9-c402-4c35-8fdd-07bb5e383ad9)

Словили статус != 0 и скрипт завершился, не показав какие ошибки были

Стало:
![image](https://github.com/tutu-ru-mobile/github-workflows/assets/13437044/11c94f99-7b8e-43ab-9a1a-68723294a3b4)

Дошли до конца скрипта