### PR TITLE
(MCORE-14) Use ubuntu_20.04 instead of ubuntu_latest

### DIFF
--- a/.github/workflows/cancel_previous_runs.yml
+++ b/.github/workflows/cancel_previous_runs.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   cancel_previous_runs:
     name: 'Cancel Previous Runs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/.github/workflows/check_android_pr_with_detekt.yml
+++ b/.github/workflows/check_android_pr_with_detekt.yml
@@ -17,10 +17,10 @@ concurrency:
 
 jobs:
   check_pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel previous runs
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
           - uses: styfle/cancel-workflow-action@0.11.0
             with:

--- a/.github/workflows/check_pull_request.yml
+++ b/.github/workflows/check_pull_request.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   check_pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name  == 'pull_request'
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/run_android_ui_tests.yml
+++ b/.github/workflows/run_android_ui_tests.yml
@@ -59,7 +59,7 @@ concurrency:
 
 jobs:
   run_ui_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_android_unit_tests.yml
+++ b/.github/workflows/run_android_unit_tests.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   run_unit_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_record_snapshots.yml
+++ b/.github/workflows/run_record_snapshots.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   cancel_previous_runs:
     name: 'Cancel Previous Runs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/.github/workflows/run_version_bump.yml
+++ b/.github/workflows/run_version_bump.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   cancel_previous_runs:
     name: 'Cancel Previous Runs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/.github/workflows/send_alert_to_telegram.yml
+++ b/.github/workflows/send_alert_to_telegram.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   send_alert:
     name: 'Send alert'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: echo "Start send"
       - if: ${{ inputs.send_status == 'failure' }}


### PR DESCRIPTION
Чтоб избавиться от ошибки
`##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.`

https://github.com/actions/runner-images/issues/6709