### PR TITLE
MCORE-89: Swiftlint dynamic folder path

### DIFF
--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -63,7 +63,7 @@ jobs:
         fi
 
         PATHS_LIST=""
-        if [[ -z ${{ inputs.paths }} ]]; then
+        if [ -z ${{ inputs.paths }} ]; then
           # - Этап поиска папок для линта
 
           # Получаем список уникальных папок, в которых поменялись swift-файлы

--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -81,6 +81,15 @@ jobs:
           # Ищем папки с назанием NAME из предыдущего шага. Все .swift файлы в этой папке будут линтоваться с помощью соответствующего конфига
           PATHS_LIST=$( for file in ${NAMES[@]}; do find $FOLDERS -type d -path "*/$file" | head -n 1; done )
 
+          echo "--> Changed files: $CHANGED_FILES"
+          echo "\n"
+          echo "--> FOLDERS: $FOLDERS"
+          echo "\n"
+          echo "--> NAMES: $NAMES"
+          echo "\n"
+          echo "--> PATHS_LIST: $PATHS_LIST"
+          echo "\n"
+
           # - Конец этапа поиска папок для линта
         else
           PATHS_LIST=$(echo ${{ inputs.paths }} | sed 's/,/ /g')

--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -63,27 +63,10 @@ jobs:
         fi
 
         PATHS_LIST=""
-        
+
         # Чтобы слить в мастер и запустить плавную перекатку на новый флоу
         if [ -z ${{ inputs.paths }} ]; then
-          # - Этап поиска папок для линта
-
-          # Получаем список уникальных папок, в которых поменялись swift-файлы
-          FOLDERS=$( for file in ${CHANGED_FILES[@]}; do echo $file | cut -d '/' -f1; done | grep -E "^\w*$" | uniq )
-
-          # Устанавливаем папку поиска, если она есть. Иначе поиск будет происходить в рутовой папке без проверки вложенных папок
-          CONFIG_SEARCH_FOLDER="."
-          if [ ! -z ${{ inputs.config_path }} ]; then CONFIG_SEARCH_FOLDER=${{ inputs.config_path }}; fi
-
-          # 1. Получаем из папки с конфигами полный список конфигов, которые удобавлетворяют шаблону "*.swiftlint.yml"
-          # 2. Получает NAME из строки *NAME.swiftlint.yml
-          # 3. Оставляем варианты без специальных символов (например, отправсывает /Core/)
-          NAMES=$(find $CONFIG_SEARCH_FOLDER -maxdepth 1 -type f -path "*.swiftlint.yml" | sed 's/.*\.\(.*\)\.swiftlint\.yml/\1/' | grep -E "^\w*$")
-
-          # Ищем папки с назанием NAME из предыдущего шага. Все .swift файлы в этой папке будут линтоваться с помощью соответствующего конфига
-          PATHS_LIST=$( for file in ${NAMES[@]}; do find $FOLDERS -type d -path "*/$file" | head -n 1; done )
-
-          # - Конец этапа поиска папок для линта
+          PATHS_LIST=$( for file in ${CHANGED_FILES[@]}; do echo $file | cut -d '/' -f 1,2; done | uniq )
         else
           PATHS_LIST=$(echo ${{ inputs.paths }} | sed 's/,/ /g')
         fi
@@ -97,6 +80,11 @@ jobs:
             origin_config_path=$origin_config_name
             if [ ! -z ${{ inputs.config_path }} ]; then
               origin_config_path="${{ inputs.config_path }}/$origin_config_path"
+            fi
+
+            if [[ ! -f $origin_config_path ]]; then
+              echo "Configuration file $origin_config_path doesn't exist. Skip"
+              continue
             fi
       
             # - start temp config setup -

--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -63,6 +63,8 @@ jobs:
         fi
 
         PATHS_LIST=""
+        
+        # Чтобы слить в мастер и запустить плавную перекатку на новый флоу
         if [ -z ${{ inputs.paths }} ]; then
           # - Этап поиска папок для линта
 
@@ -80,15 +82,6 @@ jobs:
 
           # Ищем папки с назанием NAME из предыдущего шага. Все .swift файлы в этой папке будут линтоваться с помощью соответствующего конфига
           PATHS_LIST=$( for file in ${NAMES[@]}; do find $FOLDERS -type d -path "*/$file" | head -n 1; done )
-
-          echo "--> Changed files: $CHANGED_FILES"
-          echo "\n"
-          echo "--> FOLDERS: $FOLDERS"
-          echo "\n"
-          echo "--> NAMES: $NAMES"
-          echo "\n"
-          echo "--> PATHS_LIST: $PATHS_LIST"
-          echo "\n"
 
           # - Конец этапа поиска папок для линта
         else

--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -23,6 +23,10 @@ on:
         default: ""
         type: string
         required: false
+      dynamic_folder_path:
+        default: false
+        type: boolean
+        required: false
     secrets:
       github_access_token:
         required: true
@@ -62,24 +66,29 @@ jobs:
           exit 0
         fi
 
-        # - Этап поиска папок для линта
+        PATHS_LIST=""
+        if [[ ${{ inputs.dynamic_folder_path }} == true ]]; then
+          # - Этап поиска папок для линта
 
-        # Приводим список рутовых папок к нужному формату (заменяет запятые на пробелы)
-        FOLDERS=$(echo ${{ inputs.paths }} | sed 's/,/ /g')
+          # Приводим список рутовых папок к нужному формату (заменяет запятые на пробелы)
+          FOLDERS=$(echo ${{ inputs.paths }} | sed 's/,/ /g')
 
-        # Устанавливаем папку поиска, если она есть. Иначе поиск будет происходить в рутовой папке без проверки вложенных папок
-        CONFIG_SEARCH_FOLDER="."
-        if [ ! -z ${{ inputs.config_path }} ]; then CONFIG_SEARCH_FOLDER=${{ inputs.config_path }}; fi
+          # Устанавливаем папку поиска, если она есть. Иначе поиск будет происходить в рутовой папке без проверки вложенных папок
+          CONFIG_SEARCH_FOLDER="."
+          if [ ! -z ${{ inputs.config_path }} ]; then CONFIG_SEARCH_FOLDER=${{ inputs.config_path }}; fi
 
-        # 1. Получаем из папки с конфигами полный список конфигов, которые удобавлетворяют шаблону "*.swiftlint.yml"
-        # 2. Получает NAME из строки *NAME.swiftlint.yml
-        # 3. Оставляем варианты без специальных символов (например, отправсывает /Core/)
-        NAMES=$(find $CONFIG_SEARCH_FOLDER -maxdepth 1 -type f -path "*.swiftlint.yml" | sed 's/.*\.\(.*\)\.swiftlint\.yml/\1/' | grep -E "^\w*$")
+          # 1. Получаем из папки с конфигами полный список конфигов, которые удобавлетворяют шаблону "*.swiftlint.yml"
+          # 2. Получает NAME из строки *NAME.swiftlint.yml
+          # 3. Оставляем варианты без специальных символов (например, отправсывает /Core/)
+          NAMES=$(find $CONFIG_SEARCH_FOLDER -maxdepth 1 -type f -path "*.swiftlint.yml" | sed 's/.*\.\(.*\)\.swiftlint\.yml/\1/' | grep -E "^\w*$")
 
-        # Ищем папки с назанием NAME из предыдущего шага. Все .swift файлы в этой папке будут линтоваться с помощью соответствующего конфига
-        PATHS_LIST=$( for file in ${NAMES[@]}; do find $FOLDERS -type d -path "*/$file" | head -n 1; done )
+          # Ищем папки с назанием NAME из предыдущего шага. Все .swift файлы в этой папке будут линтоваться с помощью соответствующего конфига
+          PATHS_LIST=$( for file in ${NAMES[@]}; do find $FOLDERS -type d -path "*/$file" | head -n 1; done )
 
-        # - Конец этапа поиска папок для линта
+          # - Конец этапа поиска папок для линта
+        else
+          PATHS_LIST=$(echo ${{ inputs.paths }} | awk -F ',' '{ for( i=1; i<=NF; i++ ) print $i }' )
+        fi
         
         linter_errors=""
         for path in ${PATHS_LIST[@]}; do

--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       paths:
-        description: 'Paths for linting folders from root separated by comma'
+        description: 'Paths for linting root folders from root separated by comma'
         default: ""
         type: string
         required: true
@@ -51,6 +51,7 @@ jobs:
 
         url=https://api.github.com/repos/$GITHUB_REPOSITORY/compare/$GITHUB_BASE_REF...$GITHUB_HEAD_REF
         echo "Get file diffs from $url"
+        # Получаем диф между текущей веткой и веткой-назначения
         CHANGED_FILES=$( \
         curl -H "Accept: application/vnd.github.v3.diff" -H "Authorization: token ${{ secrets.github_access_token }}" $url \
             | { grep -E '^diff --git (a\/.+.swift) (b\/.+.swift)$' || :; } \
@@ -60,10 +61,29 @@ jobs:
           echo "Nothing to lint"
           exit 0
         fi
+
+        # - Этап поиска папок для линта
+
+        # Приводим список рутовых папок к нужному формату (заменяет запятые на пробелы)
+        FOLDERS=$(echo ${{ inputs.paths }} | sed 's/,/ /g')
+
+        # Устанавливаем папку поиска, если она есть. Иначе поиск будет происходить в рутовой папке без проверки вложенных папок
+        CONFIG_SEARCH_FOLDER="."
+        if [ ! -z ${{ inputs.config_path }} ]; then CONFIG_SEARCH_FOLDER=${{ inputs.config_path }}; fi
+
+        # 1. Получаем из папки с конфигами полный список конфигов, которые удобавлетворяют шаблону "*.swiftlint.yml"
+        # 2. Получает NAME из строки *NAME.swiftlint.yml
+        # 3. Оставляем варианты без специальных символов (например, отправсывает /Core/)
+        NAMES=$(find $CONFIG_SEARCH_FOLDER -maxdepth 1 -type f -path "*.swiftlint.yml" | sed 's/.*\.\(.*\)\.swiftlint\.yml/\1/' | grep -E "^\w*$")
+
+        # Ищем папки с назанием NAME из предыдущего шага. Все .swift файлы в этой папке будут линтоваться с помощью соответствующего конфига
+        PATHS_LIST=$( for file in ${NAMES[@]}; do find $FOLDERS -type d -path "*/$file" | head -n 1; done )
+
+        # - Конец этапа поиска папок для линта
         
-        paths_list=$(echo ${{ inputs.paths }} | awk -F ',' '{ for( i=1; i<=NF; i++ ) print $i }' )
         linter_errors=""
-        for path in ${paths_list[@]}; do
+        for path in ${PATHS_LIST[@]}; do
+            # Получаем имя папки для анализа
             last_path=$(echo $path | awk -F "/" '{print $NF}')
 
             origin_config_name=".$last_path.swiftlint.yml"
@@ -80,9 +100,16 @@ jobs:
             echo -e "parent_config: $origin_config_path\n\ndisabled_rules:\n    - todo" >> $temp_config
             # - done temp config setup -
 
+            # - Этап формирования списка проверяемых файлов
             source_dir=$path
+
+            # Из измененных файлов берём только те, что лежат в проверяемой папке
             filtered=$( for file in ${CHANGED_FILES[@]}; do echo $file; done | { grep -E "^$source_dir/" || :; } )
+
+            # Берём только файлы (исключаем папки)
             filtered=$( for file in ${filtered[@]}; do if [ -f $file ]; then echo $file; fi done )
+            # - Конец этап формирования списка проверяемых файлов
+
             config_args=""
 
             if [ -n "$filtered" ]; then

--- a/.github/workflows/run_swiftlint.yml
+++ b/.github/workflows/run_swiftlint.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       paths:
-        description: 'Paths for linting root folders from root separated by comma'
+        description: 'Paths for linting folders from root separated by comma'
         default: ""
         type: string
-        required: true
+        required: false
       is_strict:
         description: 'Any lint warnings will be determine as error'
         default: false
@@ -22,10 +22,6 @@ on:
         description: 'Custom base path for swiftlint configuration file. Config search will be performed on the root if path does not specified'
         default: ""
         type: string
-        required: false
-      dynamic_folder_path:
-        default: false
-        type: boolean
         required: false
     secrets:
       github_access_token:
@@ -67,11 +63,11 @@ jobs:
         fi
 
         PATHS_LIST=""
-        if [[ ${{ inputs.dynamic_folder_path }} == true ]]; then
+        if [[ -z ${{ inputs.paths }} ]]; then
           # - Этап поиска папок для линта
 
-          # Приводим список рутовых папок к нужному формату (заменяет запятые на пробелы)
-          FOLDERS=$(echo ${{ inputs.paths }} | sed 's/,/ /g')
+          # Получаем список уникальных папок, в которых поменялись swift-файлы
+          FOLDERS=$( for file in ${CHANGED_FILES[@]}; do echo $file | cut -d '/' -f1; done | grep -E "^\w*$" | uniq )
 
           # Устанавливаем папку поиска, если она есть. Иначе поиск будет происходить в рутовой папке без проверки вложенных папок
           CONFIG_SEARCH_FOLDER="."
@@ -87,7 +83,7 @@ jobs:
 
           # - Конец этапа поиска папок для линта
         else
-          PATHS_LIST=$(echo ${{ inputs.paths }} | awk -F ',' '{ for( i=1; i<=NF; i++ ) print $i }' )
+          PATHS_LIST=$(echo ${{ inputs.paths }} | sed 's/,/ /g')
         fi
         
         linter_errors=""


### PR DESCRIPTION
Раньше нужно было передавать список папок, для которых возможно запустить линтинг. Но ожидаемо столкнулись с проблемой - забыли добавить папку - не запустили линтер на CI. А на ПРах начали замечать, что попадает кривой код.

Теперь папка для проверки берётся из диффа (`Dir1/Dir2/Dir3/Content.swift -> Dir1/Dir2`). Если для папки нет соответствующего файла конфига, то пропускает итерацию.