### PR TITLE
MCORE-145: Dangerfile.swift

### DIFF
--- a/.github/workflows/swift_check_pull_request.yml
+++ b/.github/workflows/swift_check_pull_request.yml
@@ -3,11 +3,6 @@ name: Check pull request
 on:
   workflow_call:
     inputs:
-      dangerfile_path:
-        description: 'Path to Dangerfile'
-        default: 'vendor/ProjectUtils/Scripts/Dangerfile.swift'
-        type: string
-        required: false
       release_branch_pattern:
         description: 'Regex pattern for release branch. Like: release/(transport|avia|bus|train)-'
         type: string
@@ -36,7 +31,9 @@ jobs:
           ssh-private-key: ${{ secrets.ssh_private_key }}
 
       - name: Sync Dangerfile
-        run: ./download_project_utils.sh
+        run: |
+          ./download_project_utils.sh
+          cp -f vendor/ProjectUtils/Scripts/Dangerfile.swift Dangerfile.swift
 
       - name: Create diff file
         run: |
@@ -46,7 +43,7 @@ jobs:
       - name: Danger
         uses: docker://ghcr.io/danger/danger-swift:3.18.0
         with:
-            args: --failOnErrors --dangerfile ${{ inputs.dangerfile_path }}
+            args: --failOnErrors -dangerfile Dangerfile.swift
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.github_access_token }}
           DANGER_RELEASE_BRANCH_PATTERN: ${{ inputs.release_branch_pattern }}

--- a/.github/workflows/swift_check_pull_request.yml
+++ b/.github/workflows/swift_check_pull_request.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Danger
         uses: docker://ghcr.io/danger/danger-swift:3.18.0
         with:
-            args: --failOnErrors -dangerfile ${{ inputs.dangerfile_path }}
+            args: --failOnErrors --dangerfile ${{ inputs.dangerfile_path }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.github_access_token }}
           DANGER_RELEASE_BRANCH_PATTERN: ${{ inputs.release_branch_pattern }}
           DANGER_DIFF_FILE: "diff.txt"
-          
+
       - if: always()
         name: Post
         run: rm diff.txt

--- a/.github/workflows/swift_check_pull_request.yml
+++ b/.github/workflows/swift_check_pull_request.yml
@@ -1,0 +1,57 @@
+name: Check pull request
+
+on:
+  workflow_call:
+    inputs:
+      dangerfile_path:
+        description: 'Path to Dangerfile'
+        default: 'vendor/ProjectUtils/Scripts/Dangerfile.swift'
+        type: string
+        required: false
+      release_branch_pattern:
+        description: 'Regex pattern for release branch. Like: release/(transport|avia|bus|train)-'
+        type: string
+        required: true
+    secrets:
+      github_access_token:
+        required: true
+      ssh_private_key:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_pr:
+    runs-on: ubuntu-latest
+    if: github.event_name  == 'pull_request'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3.1.0
+
+      - name: Setup SSH
+        uses: tutu-ru-mobile/gh-actions-setup-ssh@v1
+        with:
+          ssh-private-key: ${{ secrets.ssh_private_key }}
+
+      - name: Sync Dangerfile
+        run: ./download_project_utils.sh
+
+      - name: Create diff file
+        run: |
+          URL=https://api.github.com/repos/$GITHUB_REPOSITORY/compare/$GITHUB_BASE_REF...$GITHUB_HEAD_REF
+          curl -H "Accept: application/vnd.github.v3.diff" -H "Authorization: token ${{ secrets.github_access_token }}" $URL > diff.txt
+
+      - name: Danger
+        uses: docker://ghcr.io/danger/danger-swift:3.18.0
+        with:
+            args: --failOnErrors -dangerfile ${{ inputs.dangerfile_path }}
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.github_access_token }}
+          DANGER_RELEASE_BRANCH_PATTERN: ${{ inputs.release_branch_pattern }}
+          DANGER_DIFF_FILE: "diff.txt"
+          
+      - if: always()
+        name: Post
+        run: rm diff.txt


### PR DESCRIPTION
# [MCORE-145](https://hq.tutu.ru/browse/MCORE-145): Переписать DangerFile на Swift
`Dangerfile` был переписан на Swift. 

## Важное замечание
В связи с тем, что Ruby очень многое делает под капотом, то в Swift реализации `dangerfile` пришлось отказаться от использования встроенных функций для работы с `git diff`. Вместо этого diff файл формируется перед вызовом `dangerfile` и в скрипт передается путь до этого файла. Парсинг данного файла реализован дополнительно.

> [!NOTE]
> После переезда на собственную CI ферму решение будет пересмотрено в пользу предоставляемого `danger-swift`