### PR TITLE
NO-ISSUE: Danger v6 in farm tests

### DIFF
--- a/.github/workflows/run_farm_xcode_tests.yml
+++ b/.github/workflows/run_farm_xcode_tests.yml
@@ -219,7 +219,7 @@ jobs:
       - if: ${{ inputs.is_collect_issues }}
         continue-on-error: true
         name: Collect issues
-        uses: MeilCli/danger-action@v5
+        uses: MeilCli/danger-action@v6
         with:
           plugins_file: 'Gemfile'
           install_path: 'vendor/bundle'


### PR DESCRIPTION
Есть подозрения, что v5 стал работать нестабильно. 
У чекаута часто вылетает вот такая ошибка
![telegram-cloud-photo-size-2-5303343734005555616-y](https://github.com/user-attachments/assets/23f21a49-fc57-404b-90d6-678fe03737e1)

Кажется, что обновление помогло
