### PR TITLE
MCORE-427: update emulator script

### DIFF
--- a/.github/workflows/run_farm_emulator_android_ui_tests.yml
+++ b/.github/workflows/run_farm_emulator_android_ui_tests.yml
@@ -131,25 +131,13 @@ jobs:
           CLEAR_PACKAGE_DATA: ${{ inputs.marathon_clear_package_data }}
           ONLY_RECORD_SNAPSHOTS: ${{ inputs.marathon_only_record_snapshots }}
 
-      - name: Copy screenshots
-        continue-on-error: true
-        run: |
-          echo "Copying screenshots"
-          # Получаем директорию с сохраненными скриншотами
-          INTERNAL_SCREENSHOTS_PATH=$(adb logcat -d | grep -i "Snapshot saved" | head -n 1 | sed -n 's|.*Snapshot saved to \(/.*\)/.*|\1/|p')
-          mkdir screenshots
-          # Получает список id подключенных девайсов, и для каждого копирует содержимое папки screenshots в текущую директорию screenshots
-          adb devices | tail -n +2 | cut -sf 1 | \
-            xargs -I {} adb -s {} pull $INTERNAL_SCREENSHOTS_PATH $SCREENSHOTS_PATH \
-            2>&1
-
       - name: Upload test results
         continue-on-error: true
         if: inputs.upload_test_results
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.uploaded_artifact_name }}
-          path: ${{ env.SCREENSHOTS_PATH }}
+          path: ${{ inputs.marathon_path }}/build/reports/marathon/device-files/Screenshots
 
       - name: Stop measuring workflow duration
         id: seconds_from_date

--- a/.github/workflows/run_ui_tests.yml
+++ b/.github/workflows/run_ui_tests.yml
@@ -42,7 +42,7 @@ jobs:
       uploaded_artifact_name: "ptt"
       assemble_task: ":ptt:ptt_app:assembleGoogleStoreDebug"
       assemble_android_test_task: ":ptt:ptt_app:assembleGoogleStoreDebugAndroidTest"
-      marathon_clear_package_data: false
+      marathon_clear_package_data: true
       marathon_only_record_snapshots: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
       uploaded_artifact_name: "avia"
       assemble_task: "avia_app:assembleGoogleStoreDebug"
       assemble_android_test_task: "avia_app:assembleGoogleStoreDebugAndroidTest"
-      marathon_clear_package_data: false
+      marathon_clear_package_data: true
       marathon_only_record_snapshots: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
       uploaded_artifact_name: "train"
       assemble_task: "train_app:assembleGoogleStoreDebug"
       assemble_android_test_task: "train_app:assembleGoogleStoreDebugAndroidTest"
-      marathon_clear_package_data: false
+      marathon_clear_package_data: true
       marathon_only_record_snapshots: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Обновила скрипт для рекорда – скриншоты теперь собираются из репортов марафона.