### PR TITLE
MCORE-642: remove unused ssh setup

### DIFF
--- a/.github/workflows/swift_check_pull_request.yml
+++ b/.github/workflows/swift_check_pull_request.yml
@@ -23,16 +23,11 @@ concurrency:
 
 jobs:
   check_pr:
-    runs-on: [tutu-mac-builder]
+    runs-on: tutu-mac-builder
     if: github.event_name  == 'pull_request'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Setup SSH
-        uses: tutu-ru-mobile/gh-actions-setup-ssh@v1
-        with:
-          ssh-private-key: ${{ secrets.ssh_private_key }}
 
       - name: Sync Dangerfile
         run: |


### PR DESCRIPTION
- удалил вызов ssh-сетапа на ферме, т.к. на ферме он уже преднастроен


А то тут упало https://github.com/tutu-ru-mobile/ios-core/actions/runs/10832193633/job/30055933004?pr=4647

Успешный прогон https://github.com/tutu-ru-mobile/ios-core/actions/runs/10832311580/job/30056337841?pr=4647