### PR TITLE
MCORE-611: Fix run on simulator iOS 17.2

### DIFF
--- a/.github/workflows/run_farm_record_snapshots.yml
+++ b/.github/workflows/run_farm_record_snapshots.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: tutu-mac-builder
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,name=iPhone 11']
+        destination: ['platform=iOS Simulator,name=iPhone 11,OS=17.2']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.1.0

--- a/.github/workflows/run_farm_xcode_tests.yml
+++ b/.github/workflows/run_farm_xcode_tests.yml
@@ -104,6 +104,9 @@ jobs:
       minutes: ${{ steps.runtime.outputs.minutes }}
       seconds: ${{ steps.runtime.outputs.seconds }}
       launch_id: ${{ steps.set-output.outputs.LAUNCH_ID }}
+    strategy:
+      matrix:
+        destination: ['platform=iOS Simulator,name=iPhone 11,OS=17.2']
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'record') }}
     runs-on: tutu-mac-builder
     continue-on-error: true
@@ -152,7 +155,7 @@ jobs:
             -skipPackagePluginValidation \
             -workspace ${{ inputs.workspace_name }} \
             -scheme ${{ inputs.scheme_name }} \
-            -destination "platform=iOS Simulator,name=iPhone 11" \
+            -destination "${{destination}}"" \
             -resultBundlePath '${{ inputs.xcresult_name }}' \
             -retry-tests-on-failure \
             -test-iterations '${{ inputs.test-iterations }}' \
@@ -163,6 +166,9 @@ jobs:
             $(if [ -n "${{ inputs.is_only_testing }}" ]; then echo "-only-testing ${{ inputs.is_only_testing }}"; fi) \
             $(if [ -n "${{ inputs.test_plan_name }}" ]; then echo "-testPlan ${{ inputs.test_plan_name }}"; fi) \
           | bundle exec xcpretty
+        env:
+          destination: ${{ matrix.destination }}
+
       - name: Remove ci tag
         run: rm .ci_tag
           

--- a/.github/workflows/run_record_snapshots.yml
+++ b/.github/workflows/run_record_snapshots.yml
@@ -57,8 +57,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,name=iPhone 11']
-        swift: ["5.5"]
+        destination: ['platform=iOS Simulator,name=iPhone 11,OS=17.2']
     steps:
       - name: System info
         run: |

--- a/.github/workflows/run_xcode_tests.yml
+++ b/.github/workflows/run_xcode_tests.yml
@@ -56,8 +56,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,name=iPhone 11']
-        swift: ["5.5"]
+        destination: ['platform=iOS Simulator,name=iPhone 11,OS=17.2']
     steps:
       - name: Start time
         id: starttime


### PR DESCRIPTION
- Возникает иногда бага, что симулятор не найден
- А он реально не найден, потому что xcodebuild ищет latest симулятор(на данный момент это 17.4), мы пока еще используем 17.2
- вот указал версию ОС в симуляторе напрямую
