### PR TITLE
MCORE-649: Mark deprecated

### DIFF
--- a/.github/workflows/check_pull_request.yml
+++ b/.github/workflows/check_pull_request.yml
@@ -1,4 +1,4 @@
-name: Check pull request
+name: (!!! Deprecated) Check pull request
 
 on:
   workflow_call:

--- a/.github/workflows/ios_check_pull_request.yml
+++ b/.github/workflows/ios_check_pull_request.yml
@@ -1,4 +1,4 @@
-name: Check pull request
+name: (!!! Deprecated) Check pull request
 
 on:
   workflow_call:

--- a/.github/workflows/run_danger_kotlin.yml
+++ b/.github/workflows/run_danger_kotlin.yml
@@ -20,7 +20,7 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/run_farm_xcode_tests.yml
+++ b/.github/workflows/run_farm_xcode_tests.yml
@@ -222,17 +222,17 @@ jobs:
         env:
           PROJECT_ID: ${{ inputs.project_id }}
           
-      - if: ${{ inputs.is_collect_issues }}
-        continue-on-error: true
-        name: Collect issues
-        uses: MeilCli/danger-action@v6
-        with:
-          plugins_file: 'Gemfile'
-          install_path: 'vendor/bundle'
-          danger_file: ${{ inputs.dangerfile_name }}
-          danger_id: 'danger-pr'
-        env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.github_access_token }}
+      # - if: ${{ inputs.is_collect_issues }}
+      #   continue-on-error: true
+      #   name: Collect issues
+      #   uses: MeilCli/danger-action@v6
+      #   with:
+      #     plugins_file: 'Gemfile'
+      #     install_path: 'vendor/bundle'
+      #     danger_file: ${{ inputs.dangerfile_name }}
+      #     danger_id: 'danger-pr'
+      #   env:
+      #     DANGER_GITHUB_API_TOKEN: ${{ secrets.github_access_token }}
       - id: step1
         run: |
           if [ $? -eq 0 ]; then

--- a/.github/workflows/run_xcode_tests.yml
+++ b/.github/workflows/run_xcode_tests.yml
@@ -1,4 +1,4 @@
-name: Run Xcode tests
+name: (!!!Deprecated) Run Xcode tests
 
 on:
   workflow_call:


### PR DESCRIPTION
- отметил задепрекейченные флоу
- отключил повторный прогон Danger для ios проектов (потому что и так прогоняется, но для свифта)
