### PR TITLE
MCORE-664: update Dangerfile to support diff

### DIFF
--- a/.github/workflows/run_danger_kotlin.yml
+++ b/.github/workflows/run_danger_kotlin.yml
@@ -24,6 +24,12 @@ jobs:
   pull-request:
     runs-on: tutu-mac-builder
     steps:
+      - name: Remove old config files
+        continue-on-error: true
+        run: |
+          rm config/detekt/detekt.yml
+          rm Dangerfile.df.kts
+
       - uses: actions/checkout@v4
 
       - name: Copy detekt config

--- a/action_copy_config/action.yml
+++ b/action_copy_config/action.yml
@@ -15,6 +15,7 @@ runs:
         target_dir="$(dirname ${{ inputs.file_path }})"
         target_file="$(basename ${{ inputs.file_path }})"
         mkdir -p "$target_dir"
-        rm -f "$target_dir/$target_file"
-        cp "${{ github.action_path }}/${{ inputs.file_path }}" "$target_dir/$target_file"
+        if [ ! -f $target_dir/$target_file ]; then
+          cp "${{ github.action_path }}/${{ inputs.file_path }}" "$target_dir/$target_file"
+        fi
       shell: bash


### PR DESCRIPTION
Добавила очистку старых конфигов перед чекаутом + обновила Dangerfile.

Dangerfile берет список измененных и добавленных файлов в репо и если violation находится в этом файле, то печатает его. У detekt не поддерживется анализ diff'a и не работают include/exclude, поэтому сделала как решение у плагина для ruby – фильтрация по списку измененных+добавленных файлов.
Если ошибка находится не в измененном файле, то она не будет выведена.