### PR TITLE
MCORE-688: add sharding

### DIFF
--- a/.github/workflows/run_farm_emulator_android_ui_tests.yml
+++ b/.github/workflows/run_farm_emulator_android_ui_tests.yml
@@ -121,25 +121,37 @@ jobs:
           MAVEN_READONLY_TOKEN: ${{ secrets.maven_readonly_token }}
           GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: ${{ inputs.is_gradle_cache_debug_enabled }}
 
+      - name: Calculate number of emulators
+        run: |
+          if [[ ${{ inputs.test_plan }} == 'FullTestPlan' || ${{ inputs.test_plan }} == 'SnapshotTest' ]]; then
+          echo "emulators_count=2" >> $GITHUB_ENV
+          else
+          echo "emulators_count=1" >> $GITHUB_ENV
+          fi
+
       - name: Init emulator
         uses: tutu-ru-mobile/github-workflows/action_init_emulator@main
+        with:
+          copies: ${{ env.emulators_count }}
 
       - name: Start emulators
         continue-on-error: false
         run: |
           set +e -b
           adb start-server
-          sleep 20
-          emulator @Pixel_8_API_32 \
+          sleep 2
+          for i in {1..${{ env.emulators_count }}}; do
+          emulator @Pixel_8_API_32_$i \
             -no-audio -no-boot-anim \
             -wipe-data -no-snapshot-save \
             -read-only \
             -change-language ru -change-country RU -change-locale ru-RU \
-          & adb -s emulator-5554 wait-for-device \
+          & adb -s emulator-555$i wait-for-device \
           & adb shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 10; done; input keyevent 82' \
           2>&1
-
           sleep 20
+          done
+          adb devices
 
       - name: Run tests
         timeout-minutes: 45
@@ -166,9 +178,13 @@ jobs:
           rm -rf $ALLURE_ARTIFACTS_PATH
           mkdir $ALLURE_ARTIFACTS_PATH
           
-          adb devices
-          adb shell "find /sdcard/googletest/test_outputfiles/allure-results \( -name '*.txt' -o -name '*.png' -o -name '*.json' \) -type f -print0" | xargs -0 -I {} adb pull {} $ALLURE_ARTIFACTS_PATH
-          ls $ALLURE_ARTIFACTS_PATH
+          devices=$(adb devices | tail -n +2 | cut -sf 1)
+          for device in $devices; do
+          adb -s "$device" shell 'find /sdcard/googletest/test_outputfiles/allure-results \( -name "*.txt" -o -name "*.png" -o -name "*.json" \)' | while read -r file; do
+          adb -s "$device" pull "$file" $ALLURE_ARTIFACTS_PATH
+          done
+          done
+          echo "files to be send to allure: $(ls $ALLURE_ARTIFACTS_PATH | wc -l | tr -d ' ')"
           
           RESULT=$(allurectl launch create --output json ${ALLURE_ARTIFACTS_PATH} \
           --token ${{ secrets.allure_token }} \

--- a/.github/workflows/run_farm_emulator_android_ui_tests.yml
+++ b/.github/workflows/run_farm_emulator_android_ui_tests.yml
@@ -172,6 +172,7 @@ jobs:
 
       - name: Send allure report
         id: allure_send_report
+        continue-on-error: true
         if: (!inputs.marathon_only_record_snapshots) && always()
         run: |
           ALLURE_ARTIFACTS_PATH="send_to_allure"

--- a/.github/workflows/run_farm_emulator_android_ui_tests.yml
+++ b/.github/workflows/run_farm_emulator_android_ui_tests.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Send allure report
         id: allure_send_report
-        continue-on-error: true
+        continue-on-error: false
         if: (!inputs.marathon_only_record_snapshots) && always()
         run: |
           ALLURE_ARTIFACTS_PATH="send_to_allure"

--- a/action_init_emulator/action.yml
+++ b/action_init_emulator/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: "Emulator name"
     default: Pixel_8_API_32
     required: false
+  copies:
+    description: "Copies of emulator"
+    default: "1"
 runs:
   using: "composite"
 
@@ -15,6 +18,8 @@ runs:
       run: |
         rm -r /Users/dev/.android/avd/
         mkdir -p /Users/dev/.android/avd/
-        cp ${{ github.action_path }}/android/${{ inputs.emulator }}.ini /Users/dev/.android/avd/
+        for i in {1..${{ inputs.copies }}}; do
+        cp ${{ github.action_path }}/android/${{ inputs.emulator }}.ini /Users/dev/.android/avd/${{ inputs.emulator }}_${i}.ini
+        done
         cp -R ${{ github.action_path }}/android/avd/ /Users/dev/.android/avd/
       shell: bash


### PR DESCRIPTION
Добавила 2 эмулятора вместо одного для FullTestPlan и SnapshotTest, если что можно расширить до любого количества (пока память не кончится).
Прогон – https://github.com/tutu-ru-mobile/android-core/actions/runs/11035031364/job/30650036875