### PR TITLE
MCORE-722: remove ssh from version bump

### DIFF
--- a/.github/workflows/run_farm_version_bump.yml
+++ b/.github/workflows/run_farm_version_bump.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - run: bundle install
-      - name: Change origin to ssh link
-        run: git remote set-url origin git@github.com:$GITHUB_REPOSITORY.git
       - if: ${{ inputs.is_run_fastlane }}
         name: Bump
         # Исправление как в https://github.com/tutu-ru-mobile/ios-features/blob/fe81d704ff157dab5522c91bc0329bd4ea2de3ab/.github/workflows/bump.yml#L32-L35


### PR DESCRIPTION
Убрала прослойку ssh для взаимодетсвия с fastlane, тк 
1) ssh уже настроен на машинках
2) судя по всему, через ssh fastlane переодически не видит провижены

перестает отпадать ошибка вида 
`bundler: failed to load command: fastlane (/Users/dev/actions-runner/_work/ios-designkit/ios-designkit/vendor/bundle/ruby/2.7.0/bin/fastlane)
/Users/dev/actions-runner/_work/ios-designkit/ios-designkit/vendor/bundle/ruby/2.7.0/gems/fastlane-2.221.1/fastlane_core/lib/fastlane_core/ui/interface.rb:129:in crash!': \e[31m[!] Could not retrieve response as fastlane runs in non-interactive mode\e[0m (FastlaneCore::Interface::FastlaneCrash)`

вот пример прогона зеленого дизайн кита:
https://github.com/tutu-ru-mobile/ios-designkit/actions/runs/11130683180/job/30930555122

